### PR TITLE
unescape zip paths as urls

### DIFF
--- a/lib/epub/publication/package/manifest.rb
+++ b/lib/epub/publication/package/manifest.rb
@@ -61,7 +61,7 @@ module EPUB
           def read
             rootfile = Addressable::URI.parse(manifest.package.book.ocf.container.rootfile.full_path)
             Zip::Archive.open(manifest.package.book.epub_file) {|zip|
-              path = rootfile + href.request_uri
+              path = Addressable::URI.unescape(rootfile + href.request_uri)
               zip.fopen(path.to_s).read
             }
           end


### PR DESCRIPTION
Small fix for zip paths that have spaces as %20 in them.
