### PR TITLE
Explicity #close each zip member file that has been opened via #fopen.

### DIFF
--- a/docs/Home.markdown
+++ b/docs/Home.markdown
@@ -43,11 +43,9 @@ This book object can yield page by spine's order(spine defines the order to read
 
     book.each_page_on_spine do |page|
       file = page.href # => path/to/page/in/zip/archive
-      html = Zip::Archive.open('/path/to/book.epub') do |zip|
-        zip.fopen(file.to_s) do |file|
-          file.read
-        end
-      end
+      html = Zip::Archive.open('/path/to/book.epub') {|zip|
+        zip.fopen(file.to_s) {|file| file.read}
+      }
     end
 
 And {EPUB::Publication::Package::Manifest::Item Item} provides syntax suger {EPUB::Publication::Package::Manifest::Item#read #read} for above:

--- a/lib/epub/parser/ocf.rb
+++ b/lib/epub/parser/ocf.rb
@@ -25,9 +25,7 @@ module EPUB
       def parse
         EPUB::OCF::MODULES.each do |m|
           begin
-            data = @zip.fopen(File.join(DIRECTORY, "#{m}.xml")) do |file|
-              file.read
-            end
+            data = @zip.fopen(File.join(DIRECTORY, "#{m}.xml")) {|file| file.read}
             @ocf.__send__ "#{m}=", __send__("parse_#{m}", data)
           rescue Zip::Error
           end

--- a/lib/epub/parser/publication.rb
+++ b/lib/epub/parser/publication.rb
@@ -12,9 +12,7 @@ module EPUB
 
       class << self
         def parse(zip_archive, file)
-          opf = zip_archive.fopen(Addressable::URI.unencode(file)) do |member|
-            member.read
-          end
+          opf = zip_archive.fopen(Addressable::URI.unencode(file)) {|member| member.read}
 
           new(opf, file).parse
         end

--- a/lib/epub/publication/package/manifest.rb
+++ b/lib/epub/publication/package/manifest.rb
@@ -92,9 +92,9 @@ module EPUB
           end
 
           def read
-            raw_content = Zip::Archive.open(manifest.package.book.epub_file) do |zip|
-              zip.fopen(entry_name) { |member| member.read }
-            end
+            raw_content = Zip::Archive.open(manifest.package.book.epub_file) {|zip|
+              zip.fopen(entry_name) {|member| member.read}
+            }
 
             unless media_type.start_with?('text/') or
                 media_type.end_with?('xml') or


### PR DESCRIPTION
Addresses a memory leak with the zipruby gem where using `fopen()` and `#read` without explicitly closing the file afterward will never release the memory used reading the file. This pull request uses `#fopen()` with a block so that zipruby will close the file after reading and free the memory.
