### PR TITLE
allow class including EPUB to intialize with extra arguments

### DIFF
--- a/lib/epub/parser.rb
+++ b/lib/epub/parser.rb
@@ -22,7 +22,7 @@ module EPUB
       # @example
       #   book = EPUB::Parser.parse('path/to/book.epub', :class => MyBook) # => #<MyBook:0x000000019b0568 @epub_file=...>
       #   book.instance_of? MyBook # => true
-      #
+      # 
       # @param [String] filepath
       # @param [Hash] options the type of return is specified by this argument.
       #   If no options, returns {EPUB::Book} object.

--- a/lib/epub/parser.rb
+++ b/lib/epub/parser.rb
@@ -7,10 +7,10 @@ module EPUB
   class Parser
     class << self
       # Parse an EPUB file
-      # 
+      #
       # @example
       #   EPUB::Parser.parse('path/to/book.epub') # => EPUB::Book object
-      # 
+      #
       # @example
       #   class MyBook
       #     include EPUB
@@ -18,11 +18,11 @@ module EPUB
       #   book = MyBook.new
       #   parsed_book = EPUB::Parser.parse('path/to/book.epub', :book => book) # => #<MyBook:0x000000019760e8 @epub_file=..>
       #   parsed_book.equal? book # => true
-      # 
+      #
       # @example
       #   book = EPUB::Parser.parse('path/to/book.epub', :class => MyBook) # => #<MyBook:0x000000019b0568 @epub_file=...>
       #   book.instance_of? MyBook # => true
-      # 
+      #
       # @param [String] filepath
       # @param [Hash] options the type of return is specified by this argument.
       #   If no options, returns {EPUB::Book} object.
@@ -81,7 +81,11 @@ module EPUB
       when params[:book]
         params[:book]
       when params[:class]
-        params[:class].new
+        if params[:initialize_with]
+          params[:class].new params[:initialize_with]
+        else
+          params[:class].new
+        end
       else
         Book.new
       end

--- a/lib/epub/parser.rb
+++ b/lib/epub/parser.rb
@@ -7,10 +7,10 @@ module EPUB
   class Parser
     class << self
       # Parse an EPUB file
-      #
+      # 
       # @example
       #   EPUB::Parser.parse('path/to/book.epub') # => EPUB::Book object
-      #
+      # 
       # @example
       #   class MyBook
       #     include EPUB
@@ -18,7 +18,7 @@ module EPUB
       #   book = MyBook.new
       #   parsed_book = EPUB::Parser.parse('path/to/book.epub', :book => book) # => #<MyBook:0x000000019760e8 @epub_file=..>
       #   parsed_book.equal? book # => true
-      #
+      # 
       # @example
       #   book = EPUB::Parser.parse('path/to/book.epub', :class => MyBook) # => #<MyBook:0x000000019b0568 @epub_file=...>
       #   book.instance_of? MyBook # => true


### PR DESCRIPTION
This is just an idea which I have mixed feelings about.  But it would be nice to instantiate a class with specific args.  For example:

```ruby
class Book
  include EPUB::Book::Features

  def initialize(args = {})
    @path_to_file = args[:path_to_file]
  end
end

options = {
  class: Book
  initialize_with: { path_to_file: '/path/to/file.epub' }
}

EPUB::Parser.parse('/path/to/file.epub', options)
```